### PR TITLE
Removendo configuração externaliada do Config-repository

### DIFF
--- a/k8s/configmap.yml
+++ b/k8s/configmap.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catalog-config
+  labels:
+    app: catalog-config
+data:
+  application.yml: |
+    polar:
+      greeting: Welcome to the book catalog from kubernetes!
+    spring:
+      datasource:
+        url: jdbc:postgresql://polar-postgres/polardb_catalog
+      security:
+        oauth2:
+          resourceserver:
+            jwt:
+              issuer-uri: http://polar-keycloak/realms/PolarBookshop
+    

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: catalog-service
       annotations:
-        prometheus.io/scrap: "true"
+        prometheus.io/scrape: "true"
         prometheus.io/path: /actuator/prometheus
         prometheus.io/port: "9001"
     spec:
@@ -25,22 +25,14 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["sh", "-c","sleep 5"]
+                command: [ "sh", "-c","sleep 5" ]
           ports:
             - containerPort: 9001
           env:
             - name: BPL_JVM_THREAD_COUNT
               value: "50"
-            - name: SPRING_CLOUD_CONFIG_URI
-              value: http://config-service
-            - name: SPRING_DATASOURCE_URL
-              value: jdbc:postgresql://polar-postgres/polardb_catalog
             - name: SPRING_PROFILES_ACTIVE
               value: testdata
-            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI
-              value: http://polar-keycloak/realms/PolarBookshop
-            - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI
-              value: http://polar-keycloak/realms/PolarBookshop
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
@@ -53,3 +45,10 @@ spec:
               port: 9001
             initialDelaySeconds: 5
             periodSeconds: 15
+          volumeMounts:
+            - name: catalog-config-volume
+              mountPath: /workspace/config
+      volumes:
+        - name: catalog-config-volume
+          configMap:
+            name: catalog-config

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,9 +15,10 @@ spring:
   lifecycle:
     timeout-per-shutdown-phase: 15s
   config:
-    import: "optional:configserver:"
+    import: ""
   cloud:
     config:
+      enabled: false
       uri: http://localhost:8888
       request-connect-timeout: 5000 # 5s
       request-read-timeout: 5000 # 5s
@@ -47,6 +48,7 @@ logging:
 info:
   system: Polar Bookshop
   version: Em desenvolviento
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
Removendo configuração externaliada do Config-repository utilizando spring config, para configuração de arquivos de propiedades, para configMap com Kubernates
